### PR TITLE
Fix go mod version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/acheong08/ChatGPT-Go
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/bogdanfinn/fhttp v0.5.24


### PR DESCRIPTION
Fix the error:

```bash
ChatGPT-Go/go.mod:3: invalid go version '1.21.3': must match format 1.23
```